### PR TITLE
Fix Grammar Issue with Piscine Mermaid

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
@@ -231,8 +231,8 @@
 		if(12)
 			FluffSpeak("I swear I'll be nice, you can just stay with me, even if I'm a monster...")
 		if(15)
-			response_help_continuous = "hold hands"
-			response_help_simple = "hold hands"
+			response_help_continuous = "hold hands with"
+			response_help_simple = "hold hands with"
 		if(17)
 			FluffSpeak("Are you sure you want to stay? I love you so much, I can't- I don't want to see you go.")
 		if(20)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Fixes a very critical grammar error that has been plaguing the two Piscine Mermaid lovers around the world

## Why It's Good For The Game
Grammar occasionally is important

## Changelog
:cl:
fix: You no longer "Hold hands Piscine Mermaid," but "Hold hands with Piscine Mermaid"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
